### PR TITLE
foxy-sros2 migration notes

### DIFF
--- a/source/Releases/Release-Foxy-Fitzroy.rst
+++ b/source/Releases/Release-Foxy-Fitzroy.rst
@@ -288,14 +288,15 @@ There are copies in `example_interfaces <https://index.ros.org/p/example_interfa
 - ``std_msgs/msg/UInt8``
 - ``std_msgs/msg/UInt8MultiArray``
 
-sros2
-^^^^^
+Security features
+^^^^^^^^^^^^^^^^^
 
 Use of security enclaves
 """"""""""""""""""""""""
 
-As of Foxy, domain participants are not mapped directly to ROS nodes anymore.
-The concept of security enclave was introduced, an enclave is a process or group of processes that will share the same identity and access control rules.
+As of Foxy, domain participants are no longer mapped directly to ROS nodes.
+As a result, ROS 2 security features (which are specific to domain participants) are also no longer mapped directly to ROS nodes.
+Instead, Foxy introduces the concept of a security "enclave", where an "enclave" is a process or group of processes that will share the same identity and access control rules.
 Each process using ROS Security is part of an enclave.
 
 This means that security artifacts are **not** retrieved based on the node name anymore but based on the Security enclave name.

--- a/source/Releases/Release-Foxy-Fitzroy.rst
+++ b/source/Releases/Release-Foxy-Fitzroy.rst
@@ -297,7 +297,6 @@ Use of security enclaves
 As of Foxy, domain participants are no longer mapped directly to ROS nodes.
 As a result, ROS 2 security features (which are specific to domain participants) are also no longer mapped directly to ROS nodes.
 Instead, Foxy introduces the concept of a security "enclave", where an "enclave" is a process or group of processes that will share the same identity and access control rules.
-Each process using ROS Security is part of an enclave.
 
 This means that security artifacts are **not** retrieved based on the node name anymore but based on the Security enclave name.
 A node enclave name can be set by using the ROS argument `--enclave`, e.g. `ros2 run demo_nodes_py talker --ros-args --enclave /my_enclave`

--- a/source/Releases/Release-Foxy-Fitzroy.rst
+++ b/source/Releases/Release-Foxy-Fitzroy.rst
@@ -288,6 +288,36 @@ There are copies in `example_interfaces <https://index.ros.org/p/example_interfa
 - ``std_msgs/msg/UInt8``
 - ``std_msgs/msg/UInt8MultiArray``
 
+sros2
+^^^^^
+
+Use of security enclaves
+""""""""""""""""""""""""
+
+As of Foxy, domain participants are not mapped directly to ROS nodes anymore.
+The concept of security enclave was introduced, an enclave is a process or group of processes that will share the same identity and access control rules.
+Each process using ROS Security is part of an enclave.
+
+This means that security artifacts are **not** retrieved based on the node name anymore but based on the Security enclave name.
+A node enclave name can be set by using the ROS argument `--enclave`, e.g. `ros2 run demo_nodes_py talker --ros-args --enclave /my_enclave`
+
+Related design document: https://github.com/ros2/design/pull/274
+
+Renaming of the environment variables
+"""""""""""""""""""""""""""""""""""""
+
+.. list-table:: Environment variables renaming
+   :widths: 25 25
+   :header-rows: 1
+
+   * - Name in Eloquent
+     - Name in Foxy
+   * - ROS_SECURITY_ROOT_DIRECTORY
+     - ROS_SECURITY_KEYSTORE
+   * - ROS_SECURITY_NODE_DIRECTORY
+     - ROS_SECURITY_ENCLAVE_OVERRIDE
+
+
 Known Issues
 ------------
 


### PR DESCRIPTION
Tried to keep it very succinct to match the rest of the document while still covering the main breaking changes in behaviour.

Example of omission: the renaming of the argument `--node-names` to `--enclaves` of the verb `ros2 security generate_artifacts` is not mentioned

@ros-security-wg Feedback very appreciated, especially on things that are not mentioned here (and you think should be)